### PR TITLE
feat: Use probe-rs instead of probe-run

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-runner = "probe-run --chip STM32F446RETx" # Use with probe-run (see https://github.com/knurling-rs/probe-run)
+runner = "probe-rs run --chip STM32F446RETx" # Use with probe-rs (see https://github.com/probe-rs/probe-rs)
 # runner = "arm-none-eabi-gdb -q -x openocd.gdb" # Use with GDB / OpenOCD. Note: you may need to use gdb-multiarch instead depending on your platform
 
 rustflags = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["embedded", "hardware-support", "no-std"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cortex-m = "0.7.5"
+cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 embedded-hal = "0.2.7"
 switch-hal = "0.4.0"
 stm32f4xx-hal = { version = "0.13.2", features = ["stm32f446"]}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ There are two main ways to make use of this BSP:
 Many examples are provided to illustrate both ways of using the BSP, which can be found in the `examples` directory. Use a USB cable to connect the Nucleo board's debugger to the host computer, and then run an example with cargo:
 > `cargo run --example blinky`
 
-Here, `cargo run` implicitly makes use of [probe-run](https://github.com/knurling-rs/probe-run) to flash, execute, and handle panic and backtrace info. If you prefer GDB and OpenOCD, you can change the behavior of `cargo run` by editing `.cargo/config.toml` (basic scripts for GDB and OpenOCD are provided).
+Here, `cargo run` implicitly makes use of [probe-rs](https://github.com/probe-rs/probe-rs) to flash, execute, and handle panic and backtrace info. If you prefer GDB and OpenOCD, you can change the behavior of `cargo run` by editing `.cargo/config.toml` (basic scripts for GDB and OpenOCD are provided).
 
 # Reference material
 


### PR DESCRIPTION
The probe-run carte has been deprecated,
https://ferrous-systems.com/blog/probe-run-deprecation. I followed the migration steps in the Blog Post
https://ferrous-systems.com/blog/probe-run-deprecation/#migration-steps

With this change all examples are functional, but if you have a version of probe-rs <= 0.22.0 then you may see an error; see: https://github.com/probe-rs/probe-rs/issues/2072. As a side note I used `screen /dev/ttyACM0` on my Arch Linux box to test `serial_loopback` and `serial_terminal`.